### PR TITLE
uEnv.txt: rootfs on 2nd SD card partition

### DIFF
--- a/board/pocketbeagle/uEnv.txt
+++ b/board/pocketbeagle/uEnv.txt
@@ -1,5 +1,5 @@
 fdtfile=am335x-pocketbeagle.dtb
 bootpart=0:1
 bootdir=
-bootargs=console=ttyO0,115200n8 root=/dev/mmcblk0p1 rw rootfstype=ext4 rootwait
+bootargs=console=ttyO0,115200n8 root=/dev/mmcblk0p2 rw rootfstype=ext4 rootwait
 uenvcmd=run loadimage;run loadfdt;printenv bootargs;bootz ${loadaddr} - ${fdtaddr};


### PR DESCRIPTION
Not sure how it could work before - may be u-boot used partition 2 before, by default?